### PR TITLE
Rename app

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: google-analytics-reporter
+- name: route-service
   buildpack: go_buildpack
   instances: 2
   memory: 128M


### PR DESCRIPTION
`route-service` makes more sense when having to refer to the app on
PaaS